### PR TITLE
setScanner option

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ void (async () => {
   try {
     const response = await ia.updateItem(itemId, { title: 'new title' })
     console.log(response)
-  } catch (error) {
-    console.log(error.response.data)
+  } catch (err) {
+    console.log(err.response.data)
   }
 })()
 ```

--- a/examples/example-express-ts/src/router.ts
+++ b/examples/example-express-ts/src/router.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs/promises'
 import { tmpdir } from 'os'
 
 const { IA_TOKEN } = process.env || {}
-const ia = new InternetArchive((IA_TOKEN as string), { testmode: true })
+const ia = new InternetArchive((IA_TOKEN as string), { testmode: true, setScanner: true })
 
 const router = express.Router() as Router
 
@@ -81,8 +81,8 @@ router.post(
       } else {
         throw new Error('no files attached')
       }
-    } catch (error: any) {
-      handleError(res, error)
+    } catch (err: any) {
+      handleError(res, err)
     }
   },
 )
@@ -97,8 +97,8 @@ router.put('/item/:id', async (req: Request, res: Response): Promise<void> => {
       : req.body
 
     handleResponse(res, { status: 200, data: await ia.updateItem(id, metadata) })
-  } catch (error: any) {
-    handleError(res, error)
+  } catch (err: any) {
+    handleError(res, err)
   }
 })
 
@@ -118,8 +118,8 @@ router.get('/item', async (req: Request, res: Response): Promise<void> => {
     const { filters, options } = payload || {}
 
     handleResponse(res, { status: 200, data: await ia.getItems(filters, options) })
-  } catch (error: any) {
-    handleError(res, error)
+  } catch (err: any) {
+    handleError(res, err)
   }
 })
 
@@ -128,8 +128,8 @@ router.get('/item/:id', async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params
 
     handleResponse(res, { status: 200, data: await ia.getItem(id) })
-  } catch (error: any) {
-    handleError(res, error)
+  } catch (err: any) {
+    handleError(res, err)
   }
 })
 
@@ -138,8 +138,8 @@ router.get('/item/:id/task', async (req: Request, res: Response): Promise<void> 
     const { id } = req.params
 
     handleResponse(res, { status: 200, data: await ia.getItemTasks(id) })
-  } catch (error: any) {
-    handleError(res, error)
+  } catch (err: any) {
+    handleError(res, err)
   }
 })
 

--- a/package.json
+++ b/package.json
@@ -23,13 +23,14 @@
     "dist"
   ],
   "scripts": {
-    "build": "npm run build-clean && npm run build-esm && npm run build-cjs",
+    "build": "npm run build-clean && npm run build-esm && npm run build-cjs && npm run update-package-info",
     "build-clean": "rm -rf dist",
     "build-esm": "npx tsc",
-    "build-cjs": "npx rollup dist/index.js --file dist/index.cjs --format cjs --external fs,crypto,slugify,qs",
+    "build-cjs": "npx rollup dist/index.js --file dist/index.cjs -p @rollup/plugin-json --format cjs --external fs,crypto,slugify,qs,zod",
     "lint": "npx eslint .",
     "lint:fix": "npx eslint --fix .",
-    "prepublish": "npm run lint && npm run build"
+    "prepublish": "npm run lint && npm run build",
+    "update-package-info": "echo '{\n  \"name\": \"'$npm_package_name'\",\n  \"version\": \"'$npm_package_version'\"\n}' > ./src/package-info.json"
   },
   "repository": {
     "type": "git",
@@ -41,6 +42,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.5.0",
+    "@rollup/plugin-json": "^6.1.0",
     "@stylistic/eslint-plugin": "^2.3.0",
     "@types/node": "^20.14.9",
     "@types/qs": "^6.9.15",
@@ -50,7 +52,8 @@
     "rollup": "^4.18.0",
     "tsx": "^4.15.7",
     "typescript": "^5.5.2",
-    "typescript-eslint": "^7.14.1"
+    "typescript-eslint": "^7.14.1",
+    "zod": "^3.23.8"
   },
   "engines": {
     "node": ">=18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ importers:
       '@eslint/js':
         specifier: ^9.5.0
         version: 9.5.0
+      '@rollup/plugin-json':
+        specifier: ^6.1.0
+        version: 6.1.0(rollup@4.18.0)
       '@stylistic/eslint-plugin':
         specifier: ^2.3.0
         version: 2.3.0(eslint@8.57.0)(typescript@5.5.2)
@@ -48,6 +51,9 @@ importers:
       typescript-eslint:
         specifier: ^7.14.1
         version: 7.14.1(eslint@8.57.0)(typescript@5.5.2)
+      zod:
+        specifier: ^3.23.8
+        version: 3.23.8
 
 packages:
 
@@ -235,6 +241,24 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@rollup/plugin-json@6.1.0':
+    resolution: {integrity: sha512-EGI2te5ENk1coGeADSIwZ7G2Q8CJS2sF120T7jLw4xFw9n7wIOXHo+kIYRAoVpJAN+kmqZSoO3Fp4JtoNF4ReA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
+  '@rollup/pluginutils@5.1.0':
+    resolution: {integrity: sha512-XTIWOPPcpvyKI6L1NHo0lFlCyznUEyPmPY1mc3KpPVDYulHSTvyeLNVW00QTLIAFNhR3kYnJTQHeGqU4M3n09g==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.18.0':
     resolution: {integrity: sha512-Tya6xypR10giZV1XzxmH5wr25VcZSncG0pZIjfePT0OVBvqNEurzValetGNarVrGiq66EBVAFn15iYX4w6FKgQ==}
@@ -599,6 +623,9 @@ packages:
   estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
+
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
 
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
@@ -1109,6 +1136,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.23.8:
+    resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
 snapshots:
 
   '@esbuild/aix-ppc64@0.21.5':
@@ -1228,6 +1258,20 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
+
+  '@rollup/plugin-json@6.1.0(rollup@4.18.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.1.0(rollup@4.18.0)
+    optionalDependencies:
+      rollup: 4.18.0
+
+  '@rollup/pluginutils@5.1.0(rollup@4.18.0)':
+    dependencies:
+      '@types/estree': 1.0.5
+      estree-walker: 2.0.2
+      picomatch: 2.3.1
+    optionalDependencies:
+      rollup: 4.18.0
 
   '@rollup/rollup-android-arm-eabi@4.18.0':
     optional: true
@@ -1639,6 +1683,8 @@ snapshots:
       estraverse: 5.3.0
 
   estraverse@5.3.0: {}
+
+  estree-walker@2.0.2: {}
 
   esutils@2.0.3: {}
 
@@ -2125,3 +2171,5 @@ snapshots:
   yaml@2.4.5: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.23.8: {}

--- a/src/package-info.json
+++ b/src/package-info.json
@@ -1,0 +1,4 @@
+{
+  "name": "internetarchive-sdk-js",
+  "version": "1.0.29"
+}

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1,0 +1,6 @@
+import { z } from 'zod'
+
+export const IaOptions = z.object({
+  testmode: z.boolean().optional(),
+  setScanner: z.boolean().optional(),
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from 'crypto'
 import slugify from 'slugify'
+import { ZodError } from 'zod'
 
 export function generateItemIdFromMetadata(metadata: Record<string, string>) {
   const uuid = randomBytes(8).toString('hex').toLowerCase()
@@ -17,4 +18,8 @@ export function generateItemIdFromMetadata(metadata: Record<string, string>) {
     strict: true,
     trim: true,
   })
+}
+
+export function parseZodErrorToString(err: ZodError) {
+  return err.issues.map((issue, idx) => `(${idx + 1})${issue.path?.[0]} - ${issue.message}`).join(', ')
 }


### PR DESCRIPTION
- adds `setScanner` option with default === `true`
- sets up schema for `IaOptions` and refactors error handling
- adds `update-package-info` script and `package-info.json` to store the package name and version for the scanner data